### PR TITLE
Fixing bugs in generating reaction definition and code

### DIFF
--- a/lib/Bio/KBase/ObjectAPI/KBaseBiochem/Reaction.pm
+++ b/lib/Bio/KBase/ObjectAPI/KBaseBiochem/Reaction.pm
@@ -246,7 +246,7 @@ sub createEquation {
 	}
 	for (my $i=0; $i < @{$rgt}; $i++) {
 		my $id = $rgt->[$i]->compound()->id();
-		next if $args->{protons}==0 && $id eq $hcpd->id() && $rxnCompID eq $rgt->[$i]->compartment()->id();
+		next if $args->{protons}==0 && $id eq $hcpd->id() && !$self->isTransport();
 		next if $args->{water}==0 && $id eq $wcpd->id();
 		if ($args->{format} eq "name" || $args->{format} eq "id") {
 			my $function = $args->{format};

--- a/lib/Bio/KBase/ObjectAPI/KBaseFBA/ModelReaction.pm
+++ b/lib/Bio/KBase/ObjectAPI/KBaseFBA/ModelReaction.pm
@@ -314,7 +314,7 @@ sub createEquation {
 		if ($id eq "cpd00000") {
 			$id = $rgt->modelcompound()->id();
 		}
-		next if $args->{protons} == 0 && $id eq $hcpd->id() && $rxnCompID eq $rgt->modelcompound()->modelcompartment()->compartment()->id();
+		next if $args->{protons} == 0 && $id eq $hcpd->id() && !$self->reaction()->isTransport();
 		next if $args->{water} == 0 && $id eq $wcpd->id();
 		if ($args->{format} eq "name") {
 			my $function = $args->{format};
@@ -371,7 +371,7 @@ sub createEquation {
 		}
 	}
 
-	my $code = $productcode.$sign.$reactcode;
+	my $code = $reactcode.$sign.$productcode;
 	if($args->{reverse}==1){
 		$code = $productcode.$sign.$reactcode;
     }


### PR DESCRIPTION
ModelReaction equation strings were erroneously being printed in the wrong order.

Change to printing of protons when the reaction is a transporter, a transporter must always have protons included in the equation.
