### PR TITLE
Removing apostrophes and quotes from within node text

### DIFF
--- a/lib/Bio/KBase/ObjectAPI/KBaseFBA/FBAModel.pm
+++ b/lib/Bio/KBase/ObjectAPI/KBaseFBA/FBAModel.pm
@@ -916,6 +916,7 @@ sub printSBML {
 		my ($name,$value) = @_;
 		$value =~ s/[\[\]\(\)\+]//g;
 		$value =~ s/[\s:,]/_/g;
+		$value =~ s/[\'\"]//g;
 		return $name.'="'.XML::LibXML::Document->new('1.0', 'UTF-8')->createTextNode($value)->toString .'"';
     };
 	#Printing header to SBML file


### PR DESCRIPTION
SBML file was unreadable because of characters in node text string.
