### PR TITLE
fix returning all items that match query in get_compounds(),get_reactions()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,21 +95,16 @@ deploy-libs: configure-scripts
 	rsync -arv lib/. $(TARGET)/lib/.
 
 deploy-kbscripts:
-	cp $(TARGET)/bin/fba-addaliases $(TARGET)/bin/kbfba-addaliases
 	cp $(TARGET)/bin/fba-addmedia $(TARGET)/bin/kbfba-addmedia
 	cp $(TARGET)/bin/fba-adjustbiomass $(TARGET)/bin/kbfba-adjustbiomass
 	cp $(TARGET)/bin/fba-adjustmapcomplex $(TARGET)/bin/kbfba-adjustmapcomplex
 	cp $(TARGET)/bin/fba-adjustmaprole $(TARGET)/bin/kbfba-adjustmaprole
 	cp $(TARGET)/bin/fba-adjustmapsubsystem $(TARGET)/bin/kbfba-adjustmapsubsystem
-	cp $(TARGET)/bin/fba-adjustmodel $(TARGET)/bin/kbfba-adjustmodel
 	cp $(TARGET)/bin/fba-adjusttempbiocpd $(TARGET)/bin/kbfba-adjusttempbiocpd
 	cp $(TARGET)/bin/fba-adjusttempbiomass $(TARGET)/bin/kbfba-adjusttempbiomass
 	cp $(TARGET)/bin/fba-adjusttemprxn $(TARGET)/bin/kbfba-adjusttemprxn
 	cp $(TARGET)/bin/fba-buildfbamodel $(TARGET)/bin/kbfba-buildfbamodel
-	cp $(TARGET)/bin/fba-exportfba $(TARGET)/bin/kbfba-exportfba
 	cp $(TARGET)/bin/fba-exportfbamodel $(TARGET)/bin/kbfba-exportfbamodel
-	cp $(TARGET)/bin/fba-exportgenome $(TARGET)/bin/kbfba-exportgenome
-	cp $(TARGET)/bin/fba-exportmedia $(TARGET)/bin/kbfba-exportmedia
 	cp $(TARGET)/bin/fba-exportobject $(TARGET)/bin/kbfba-exportobject
 	cp $(TARGET)/bin/fba-exportphenosim $(TARGET)/bin/kbfba-exportphenosim
 	cp $(TARGET)/bin/fba-gapfill $(TARGET)/bin/kbfba-gapfill
@@ -128,10 +123,8 @@ deploy-kbscripts:
 	cp $(TARGET)/bin/fba-importpheno $(TARGET)/bin/kbfba-importpheno
 	cp $(TARGET)/bin/fba-importprobanno $(TARGET)/bin/kbfba-importprobanno
 	cp $(TARGET)/bin/fba-importtemplate $(TARGET)/bin/kbfba-importtemplate
-	cp $(TARGET)/bin/fba-importtranslation $(TARGET)/bin/kbfba-importtranslation
 	cp $(TARGET)/bin/fba-integratesolution $(TARGET)/bin/kbfba-integratesolution
 	cp $(TARGET)/bin/fba-loadgenome $(TARGET)/bin/kbfba-loadgenome
-	cp $(TARGET)/bin/fba-queuefba $(TARGET)/bin/kbfba-queuefba
 	cp $(TARGET)/bin/fba-runfba $(TARGET)/bin/kbfba-runfba
 	cp $(TARGET)/bin/fba-runjob $(TARGET)/bin/kbfba-runjob
 	cp $(TARGET)/bin/fba-simpheno $(TARGET)/bin/kbfba-simpheno

--- a/lib/Bio/KBase/ObjectAPI/KBaseBiochem/Biochemistry.pm
+++ b/lib/Bio/KBase/ObjectAPI/KBaseBiochem/Biochemistry.pm
@@ -1091,6 +1091,26 @@ sub searchForCompound {
 	return $cpdobj;
 }
 
+=head3 searchForAllCompounds
+Definition:
+	[ Bio::KBase::ObjectAPI::KBaseBiochem::Compound ] = Bio::KBase::ObjectAPI::KBaseBiochem::Compound->searchForAllCompounds(string);
+Description:
+	Searches for a compound by ID, name, or alias and returns all matches.
+
+=cut
+
+sub searchForAllCompounds {
+	my ($self,$compound) = @_;
+	#First search by exact alias match
+	my $cpds = $self->getObjectsByAlias("compounds",$compound);
+	#Next, search by name
+	if (!defined($cpds->[0])) {
+		my $searchname = Bio::KBase::ObjectAPI::KBaseBiochem::Compound->nameToSearchname($compound);
+		$cpds = $self->queryObjects("compounds",{searchnames => $searchname});
+	}
+	return $cpds;
+}
+
 =head3 searchForReaction
 Definition:
 	Bio::KBase::ObjectAPI::KBaseBiochem::Reaction = Bio::KBase::ObjectAPI::KBaseBiochem::Reaction->searchForReaction(string);
@@ -1111,6 +1131,28 @@ sub searchForReaction {
 		$rxnobj = $self->queryObject("reactions",{uuid => $id});
 	}
 	return $rxnobj;
+}
+
+=head3 searchForAllReactions
+Definition:
+	[ Bio::KBase::ObjectAPI::KBaseBiochem::Reaction ] = Bio::KBase::ObjectAPI::KBaseBiochem::Reaction->searchForAllReactions(string);
+Description:
+	Searches for a reaction by ID, name, or alias and returns all matches.
+
+=cut
+
+sub searchForAllReactions {
+	my ($self,$id) = @_;
+	#First search by exact alias match
+	my $rxns = $self->getObjectsByAlias("reactions",$id);
+	#Next, search by name
+	if (!defined($rxns->[0])) {
+		$rxns = $self->queryObjects("reactions",{name => $id});
+	}
+	if (!defined($rxns)) {
+		$rxns = $self->queryObjects("reactions",{uuid => $id});
+	}
+	return $rxns;
 }
 
 =head3 searchForReactionByCode

--- a/lib/Bio/KBase/fbaModelServices/Impl.pm
+++ b/lib/Bio/KBase/fbaModelServices/Impl.pm
@@ -4709,29 +4709,32 @@ sub get_reactions
 	$out_reactions = [];
 	for (my $i=0; $i < @{$input->{reactions}}; $i++) {
 		my $rxn = $input->{reactions}->[$i];
-		my $obj;
+		my $objs;
 		if ($rxn =~ m/(rxn\d+)$/) {
-			$obj = $biochem->getObject("reactions",$1);
+			$objs = $biochem->getObjects("reactions",[$rxn]);
 		} else {
-			$obj = $biochem->searchForReaction($rxn);
+			$objs = $biochem->searchForAllReactions($rxn);
 		}
-		my $new;
-		if (defined($obj)) {
-			$new = {
-                id => $obj->id(),
-                abbrev => $obj->abbreviation(),
-                name => $obj->name(),
-                enzymes => $obj->getAliases("Enzyme Class"),
-				aliases => $obj->allAliases(),
-                direction => $obj->direction(),
-                reversibility => $obj->thermoReversibility(),
-                deltaG => $obj->deltaG(),
-                deltaGErr => $obj->deltaGErr(),
-                equation => $obj->equation(),
-                definition => $obj->definition()
-			};
+		for (my $r=0; $r < @{$objs}; $r++) {
+			my $new;
+			my $obj = $objs->[$r];
+			if (defined($obj)) {
+				$new = {
+	                id => $obj->id(),
+	                abbrev => $obj->abbreviation(),
+	                name => $obj->name(),
+	                enzymes => $obj->getAliases("Enzyme Class"),
+					aliases => $obj->allAliases(),
+	                direction => $obj->direction(),
+	                reversibility => $obj->thermoReversibility(),
+	                deltaG => $obj->deltaG(),
+	                deltaGErr => $obj->deltaGErr(),
+	                equation => $obj->equation(),
+	                definition => $obj->definition()
+				};
+			}
+			push(@{$out_reactions},$new);
 		}
-		push(@{$out_reactions},$new);
 	}
 	$self->_clearContext();
     #END get_reactions
@@ -4838,26 +4841,29 @@ sub get_compounds
 	$out_compounds = [];
 	for (my $i=0; $i < @{$input->{compounds}}; $i++) {
 		my $cpd = $input->{compounds}->[$i];
-		my $obj;
+		my $objs;
 		if ($cpd =~ m/(cpd\d+)$/) {
-			$obj = $biochem->getObject("compounds",$1);
+			$objs = $biochem->getObjects("compounds",[$cpd]);
 		} else {
-			$obj = $biochem->searchForCompound($cpd);
+			$objs = $biochem->searchForAllCompounds($cpd);
 		}
-		my $new;
-		if (defined($obj)) {
-			$new = {
-                id => $obj->id(),
-                name => $obj->name(),
-                abbrev => $obj->abbreviation(),
-                aliases => $obj->allAliases(),
-                charge => $obj->defaultCharge,
-                formula => $obj->formula,
-                deltaG => $obj->deltaG(),
-                deltaGErr => $obj->deltaGErr()
-			};
+		for (my $c=0; $c < @{$objs}; $c++) {
+			my $new;
+			my $obj = $objs->[$c];
+			if (defined($obj)) {
+				$new = {
+	                id => $obj->id(),
+	                name => $obj->name(),
+	                abbrev => $obj->abbreviation(),
+	                aliases => $obj->allAliases(),
+	                charge => $obj->defaultCharge,
+	                formula => $obj->formula,
+	                deltaG => $obj->deltaG(),
+	                deltaGErr => $obj->deltaGErr()
+				};
+			}
+			push(@{$out_compounds},$new);
 		}
-		push(@{$out_compounds},$new);
 	}
 	$self->_clearContext();
     #END get_compounds
@@ -7983,7 +7989,13 @@ sub export_genome
     $self->_setContext($ctx,$input);
     $input = $self->_validateargs($input,["genome","workspace","format"],{});
     my $genome = $self->_get_msobject("Genome",$input->{workspace},$input->{genome});
-    $output = $genome->export({format => $input->{format}});
+	if ($input->{format} == "genomeTO") {
+		my $genomeTO = $genome->genome_typed_object();
+		my $JSON = JSON::XS->new->utf8(1);
+		$output = $JSON->encode($genomeTO);
+	} else {
+		$output = $genome->export({format => $input->{format}});
+	}
     $self->_clearContext();
     #END export_genome
     my @_bad_returns;

--- a/scripts/fba-getcompounds.pl
+++ b/scripts/fba-getcompounds.pl
@@ -41,11 +41,16 @@ my $primaryArgs = ["Compound IDs (; delimiter)"];
 my $servercommand = "get_compounds";
 my $script = "fba-getcompounds";
 my $translation = {
-	idtype => "id_type"
+	idtype => "id_type",
+	biochem => "biochemistry",
+	biochemws => "biochemistry_workspace"
 };
 #Defining usage and options
 my $specs = [
-    [ 'pretty|p', 'Pretty print output' ]
+    [ 'idtype|i:s', 'Type of ID' ],
+    [ 'pretty|p', 'Pretty print output' ],
+    [ 'biochem|b:s', 'ID of the biochemistry database' ],
+    [ 'biochemws:s', 'ID of workspace containing biochemistry database' ]
 ];
 my ($opt,$params) = universalFBAScriptCode($specs,$script,$primaryArgs,$translation,$manpage);
 $params->{compounds} = [split(/;/,$opt->{"Compound IDs (; delimiter)"})];

--- a/scripts/fba-getreactions.pl
+++ b/scripts/fba-getreactions.pl
@@ -40,12 +40,16 @@ my $primaryArgs = ["Reaction IDs (; delimiter)"];
 my $servercommand = "get_reactions";
 my $script = "fba-getreactions";
 my $translation = {
-	idtype => "id_type"
+	idtype => "id_type",
+	biochem => "biochemistry",
+	biochemws => "biochemistry_workspace"
 };
 #Defining usage and options
 my $specs = [
     [ 'idtype|i:s', 'Type of ID' ],
-    [ 'pretty|p', 'Pretty print output' ]
+    [ 'pretty|p', 'Pretty print output' ],
+    [ 'biochem|b:s', 'ID of the biochemistry database' ],
+    [ 'biochemws:s', 'ID of workspace containing biochemistry database' ]
 ];
 my ($opt,$params) = universalFBAScriptCode($specs,$script,$primaryArgs,$translation,$manpage);
 $params->{reactions} = [split(/;/,$opt->{"Reaction IDs (; delimiter)"})];


### PR DESCRIPTION
(1) Fixed the get_compounds() and get_reactions() methods to return all items that match the query.  Previously the methods returned the first match but there can be multiple items in the biochemistry database that are a match.  (2) Added --biochem and --biochemws arguments to the fba-getcompounds and fba-getreactions commands to take advantage of support already provided by the server methods. (3) Updated the export_genome() method to support a 'genomeTO' format to return the genome in the format used by the genome annotation service.
