### PR TITLE
update fba-url to check server version

### DIFF
--- a/scripts/fba-url.pl
+++ b/scripts/fba-url.pl
@@ -15,6 +15,22 @@ my $primaryArgs = ["New server URL"];
 #Defining usage and options
 my ($opt, $usage) = describe_options(
     'fba-url <'.join("> <",@{$primaryArgs}).'> %o',
+    [ 'no-check|n', 'Do not check that the URL is valid' ],
     [ 'help|h|?', 'Print this usage information' ],
 );
 print "Current URL is:\n".fbaURL($ARGV[0])."\n";
+
+if (!defined($opt->{no_check})) {
+	my $serv = get_fba_client();
+	my $ver = '';
+	eval { $ver = $serv->version(); };
+	if($@) {
+		print STDERR "Unable to get a valid response from that endpoint.\n";
+		print STDERR $@->{message}."\n";
+		if(defined($@->{status_line})) {print STDERR $@->{status_line}."\n" };
+		print STDERR "\n";
+		exit 1;
+	}
+	print "URL is valid and running fba modeling v$ver.\n";
+}
+exit 0;


### PR DESCRIPTION
Updated fba-url command to check the server version and display it.  There already was a version() method in the server for returning the current version.  Going forward, I would like to suggest updating the server version as new features are added and bugs are fixed.
