### PR TITLE
fix setting template on fba-importfbamodel command

### DIFF
--- a/scripts/fba-importfbamodel.pl
+++ b/scripts/fba-importfbamodel.pl
@@ -20,6 +20,8 @@ my $translation = {
 	outputid => "model",
 	workspace => "workspace",
 	ignoreerrors => "ignore_errors",
+	template => "template",
+	templatews => "template_workspace"
 };
 
 my $manpage = 
@@ -101,6 +103,8 @@ my $specs = [
     [ 'genomews:s', 'Workspace with genome object' ],
     [ 'ignoreerrors|i', 'Ignore errors encountered during load' ],
     [ 'workspace|w:s', 'Workspace to save imported model in', { "default" => fbaws() } ],
+    [ 'template:s', 'ID of ModelTemplate object' ],
+    [ 'templatews:s', 'Workspace with ModelTemplate object', { "default" => fbaws() } ]
 ];
 my ($opt,$params) = universalFBAScriptCode($specs,$script,$primaryArgs,$translation, $manpage);
 if (!-e $opt->{"Model reactions file"}) {


### PR DESCRIPTION
The import_fbamodel() server method supports setting a template but the fba-importfbamodel command does not have the corresponding options.  Added --template and --templatews options to the command.