### PR TITLE
return object refs in get_template_model(), skip templateReactions in ob...

### DIFF
--- a/fbaModelServices.spec
+++ b/fbaModelServices.spec
@@ -3130,6 +3130,8 @@ module fbaModelServices {
 		string domain;
 		mapping_id map;
 		workspace_id mappingws;
+		string mapping_ref;
+		string biochemistry_ref;
 		list<TemplateReaction> reactions;
 		list<TemplateBiomass> biomasses;
     } TemplateModel;

--- a/lib/Bio/KBase/fbaModelServices/Impl.pm
+++ b/lib/Bio/KBase/fbaModelServices/Impl.pm
@@ -157,7 +157,7 @@ sub _resetKBaseStore {
 	$temp = pop(@{$temp});
 	my $newparams = {};
 	foreach my $param (keys(%{$params})) {
-		if ($param ne "fasta" && $param ne "annotations" && $param ne "genomeobj" && $param ne "gtf_file" && $param ne "sbml") {
+		if ($param ne "fasta" && $param ne "annotations" && $param ne "genomeobj" && $param ne "gtf_file" && $param ne "sbml" && $param ne "templateReactions") {
 			$newparams->{$param} = $params->{$param};
 		}
 	}
@@ -16965,6 +16965,8 @@ sub get_template_model
     	domain => $template->domain(),
     	"map" => $template->{_kbaseWSMeta}->{wsid},
     	mappingws => $template->{_kbaseWSMeta}->{ws},
+    	mapping_ref => $template->mapping_ref(),
+    	biochemistry_ref => $template->biochemistry_ref(),
     	reactions => [],
     	biomasses => []
     };


### PR DESCRIPTION
...ject store
Two fixes for template models: (1) return the references to the linked mapping and biochemistry objects from the get_template_model() method, (2) do not save the templateReactions when storing a ModelTemplate object.