### PR TITLE
Fixing possible bug in finding job id

### DIFF
--- a/lib/Bio/KBase/ObjectAPI/KBaseFBA/FBA.pm
+++ b/lib/Bio/KBase/ObjectAPI/KBaseFBA/FBA.pm
@@ -110,6 +110,7 @@ sub _buildjobid {
 		if (!-d $fulldir) {
 			File::Path::mkpath ($fulldir);
 		}
+		$path.="/" if substr($path,-1) ne "/";
 		$jobid = substr($fulldir,length($path."/"));
 	}
 	return $jobid


### PR DESCRIPTION
I'm unsure if this is necessary now, but I would get a problem from the API not being able to find the job directory.

I traced the problem to the use of substr() in this function. If the $path variable does not have the trailing slash, it's overall length is one character too short to properly include the slash in $fulldir and as such, the resulting $jobid variable would then include the slash.

One fix, implemented here, is to ensure that the $path variable is long enough. The alternative, if the $jobid itself is of a fixed length, is to use a negative offset in the substr() function.

I only encounter this problem in my local implementation of the API, and I believe it is bypassed if the $jobid is correctly set in the first place, which of course, I must not be doing in my local scripts.