### PR TITLE
small hack to fix copy of genome features

### DIFF
--- a/lib/Bio/KBase/fbaModelServices/Impl.pm
+++ b/lib/Bio/KBase/fbaModelServices/Impl.pm
@@ -19686,7 +19686,8 @@ sub models_to_community_model
 		push(@{$genomeObj->{contig_ids}},@{$mdlgenome->{contig_ids}});	
 		print "Loading features\n";
 		for (my $j=0; $j < @{$mdlgenome->features()}; $j++) {
-			$genomeObj->add("features",$mdlgenome->features()->[$j]);
+		    my $ftr = $genomeObj->add("features",$mdlgenome->features()->[$j]);
+		    $ftr->quality($mdlgenome->features()->[$j]->quality());
 		}
 		#Adding compartments to community model
 		my $cmps = $model->modelcompartments();


### PR DESCRIPTION
Currently, for whatever reason, the add() function does not correctly copy over the 'quality' sub-object of a feature, leaving it null. This throws an error when attempting to load the genome into the workspace.  The hack here explicitly copies over the quality sub-object, and has been tested locally, and will be tested in CI.