### PR TITLE
Removed http substitution in WS URL

### DIFF
--- a/lib/Bio/KBase/fbaModelServices/Impl.pm
+++ b/lib/Bio/KBase/fbaModelServices/Impl.pm
@@ -448,7 +448,6 @@ sub _workspaceServices {
 	}
 	if (!defined($self->{_workspaceServices}->{$self->_workspaceURL()})) {
 		my $url = $self->_workspaceURL();
-		$url =~ s/https/http/;
 		$self->{_workspaceServices}->{$self->_workspaceURL()} = Bio::KBase::workspace::Client->new($url);
 		$self->{_workspaceServices}->{$self->_workspaceURL()}->{token} = $self->_authentication();
 		$self->{_workspaceServices}->{$self->_workspaceURL()}->{client}->{token} = $self->_authentication();


### PR DESCRIPTION
I was debugging uploaders in Appdev, and found that tests in the FBAFileUtil were failing on calls to the WS.  I tracked it down to this issue- a substitution for any 'https' found in urls to 'http'!  It was probably convenient for testing at some point, but this seems dangerous.

I think HTTP was being redirected to HTTPS previously in CI, but a recent update (either on our end, or maybe one of the perl libs) causes this to fail with a "301 moved permanently" error against appdev and CI.  This PR fixes that.

I updated FBAFileUtil to point to my KBaseFBAModeling fork for now, and I know we are using another module for FBA tools, but we probably should make sure we aren't doing this in other places or in the new FBA tools codebase.
